### PR TITLE
Adjust minimum OS version for Munki 5.2 (#367)

### DIFF
--- a/munkitools/munkitools5.munki.recipe
+++ b/munkitools/munkitools5.munki.recipe
@@ -286,7 +286,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.10.0</string>
+                    <string>10.11</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_CORE_NAME%</string>
                     <key>requires</key>
@@ -325,7 +325,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.10.0</string>
+                    <string>10.11</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_ADMIN_NAME%</string>
                     <key>unattended_install</key>
@@ -364,7 +364,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.10.0</string>
+                    <string>10.11</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_APP_NAME%</string>
                     <key>requires</key>
@@ -404,7 +404,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.10.0</string>
+                    <string>10.11</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_APP_USAGE_NAME%</string>
                     <key>requires</key>
@@ -444,7 +444,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.10.0</string>
+                    <string>10.11</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
                 </dict>
@@ -476,7 +476,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.10.0</string>
+                    <string>10.11</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_PYTHON_NAME%</string>
                     <key>unattended_install</key>


### PR DESCRIPTION
As of Munki 5.2 release candidate 3, Munki requires 10.11.

This branch should be merged as close to the Munki 5.2 final release as possible.